### PR TITLE
[windows] Fix copy build output path not correct with Flutter SDK 3.24.0

### DIFF
--- a/lib/src/commands/build_agora_rtc_engine_example_command.dart
+++ b/lib/src/commands/build_agora_rtc_engine_example_command.dart
@@ -841,7 +841,7 @@ class BuildAgoraRtcEngineExampleCommand extends BaseCommand {
     copyDirectory(
         fileSystem,
         fileSystem.directory(path.join(_workspace.absolute.path, 'example',
-            'build', 'windows', 'runner', 'Release')),
+            'build', 'windows', 'x64', 'runner', 'Release')),
         fileSystem.directory(archiveDirPath));
 
     final pluginsDir = fileSystem.directory(path.join(


### PR DESCRIPTION
With Flutter SDK 3.24.0, the Windows build output path changes to `<project>\example\build\windows\x64\runner\Release`.