### PR TITLE
[windows] Fix copy built plugins output path not correct with Flutter SDK 3.24.0

### DIFF
--- a/lib/src/commands/build_agora_rtc_engine_example_command.dart
+++ b/lib/src/commands/build_agora_rtc_engine_example_command.dart
@@ -844,8 +844,8 @@ class BuildAgoraRtcEngineExampleCommand extends BaseCommand {
             'build', 'windows', 'x64', 'runner', 'Release')),
         fileSystem.directory(archiveDirPath));
 
-    final pluginsDir = fileSystem.directory(path.join(
-        _workspace.absolute.path, 'example', 'build', 'windows', 'plugins'));
+    final pluginsDir = fileSystem.directory(path.join(_workspace.absolute.path,
+        'example', 'build', 'windows', 'x64', 'plugins'));
     for (final pluginEntity in pluginsDir.listSync()) {
       final pluginReleaseDir = fileSystem
           .directory(path.join(pluginEntity.absolute.path, 'Release'));


### PR DESCRIPTION
With Flutter SDK 3.24.0, the Windows built plugin output path changes to `<project>\example\build\windows\x64\plugins`.