### PR TITLE
[update_native_dependencies_special_version.yml] Fix unzip failed after upgrade archive to 3.6.1

### DIFF
--- a/.github/workflows/update_native_dependencies_special_version.yml
+++ b/.github/workflows/update_native_dependencies_special_version.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.5
+          sdk: 3.5.0
 
       - uses: actions/checkout@v3
 

--- a/lib/src/common/default_file_downloader.dart
+++ b/lib/src/common/default_file_downloader.dart
@@ -63,7 +63,7 @@ Future<String> downloadAndUnzip(
     _unzipSymlinks(processManager, path.join(zipDownloadPath, zipFileBaseName),
         zipDownloadPath);
   } else {
-    _unzip(path.join(zipDownloadPath, zipFileBaseName), zipDownloadPath);
+    await _unzip(path.join(zipDownloadPath, zipFileBaseName), zipDownloadPath);
   }
 
   return zipDownloadPath;
@@ -87,8 +87,8 @@ Future<void> _unzip(String zipFilePath, String outputPath) async {
 // Decode the zip from the InputFileStream. The archive will have the contents of the
 // zip, without having stored the data in memory.
   final archive = ZipDecoder().decodeBuffer(inputStream);
-  extractArchiveToDisk(archive, outputPath);
-  inputStream.close();
+  await extractArchiveToDisk(archive, outputPath);
+  await inputStream.close();
 }
 
 String getUnzipDir(


### PR DESCRIPTION
Fix unzip failed after upgrade `archive` to 3.6.1.

Fail job:
https://github.com/littleGnAl/hoe/actions/runs/10401406497